### PR TITLE
[ONAV-1546] Add autonomy API option to start mission from current pose

### DIFF
--- a/clearpath_outdoornav_msgs/clearpath_navigation_msgs/action/ExecuteMissionByUuid.action
+++ b/clearpath_outdoornav_msgs/clearpath_navigation_msgs/action/ExecuteMissionByUuid.action
@@ -1,7 +1,15 @@
 # Action definition for executing a mission by uuid
 
 # goal
-string uuid
+
+string uuid # UUID of The mission being executed
+
+# from_start = True -> Forces the mission to execute from the beginning
+bool from_start
+
+# If from_start = False, mission will be executed from the waypoint with UUID specified.
+# If from_start = False and no start_waypoint_uuid is specified then autonomy will pick the closest waypoint
+string start_waypoint_uuid
 ---
 # result
 bool success

--- a/clearpath_outdoornav_msgs/clearpath_navigation_msgs/action/Mission.action
+++ b/clearpath_outdoornav_msgs/clearpath_navigation_msgs/action/Mission.action
@@ -2,6 +2,13 @@
 
 # goal
 clearpath_navigation_msgs/Mission mission
+
+# from_start = True -> Forces the mission to execute from the beginning
+bool from_start
+
+# If from_start = False, mission will be executed from the start_waypoint specified.
+# If from_start = False and no start_waypoint is specified then autonomy will pick the closest waypoint
+clearpath_navigation_msgs/Waypoint start_waypoint
 ---
 # result
 bool success


### PR DESCRIPTION
- Changes to the ExecuteMissionByUuid.action and Mission.action to support 'Resuming' missions and starting missions from specified waypoints.
- The combination of the 'from_start' and 'start_waypoint' field determine the behavior:
  - from_start == True will always force the mission to run from the beginning
  - from_start == False AND start_waypoint_uuid/start_waypoint == Null will let autonomy decide where to start the mission ('closest' waypoint)
  - from_start == False AND start_waypoint_uuid/start_waypoint != Null will tell autonomy to start the mission from the specified waypoint (useful in area-coverage type applications)