### PR TITLE
Add dock import/export messages, update msg comments

### DIFF
--- a/clearpath_outdoornav_msgs/clearpath_dock_msgs/CMakeLists.txt
+++ b/clearpath_outdoornav_msgs/clearpath_dock_msgs/CMakeLists.txt
@@ -21,6 +21,8 @@ add_message_files(
 add_service_files(
   FILES
     AddDock.srv
+    ExportData.srv
+    ImportData.srv
     RemoveDock.srv
     SetDockLocationById.srv
     SetDockLocationByName.srv

--- a/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ExportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ExportData.srv
@@ -1,0 +1,7 @@
+---
+# A base-64 encoded string representing a compressed version of
+# the database contents.
+# The data itself is a gzipped JSON string representing the database contents
+# This can be written to a file or used with the ImportData.srv
+# to back-up/restore the database contents
+string data

--- a/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ExportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ExportData.srv
@@ -1,7 +1,5 @@
 ---
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This can be written to a file or used with the ImportData.srv
 # to back-up/restore the database contents
 string data

--- a/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ImportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ImportData.srv
@@ -1,6 +1,4 @@
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This is the same as the data output by the ExportData service, and is intended
 # to be used to restore the database to a previous state
 string data

--- a/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ImportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_dock_msgs/srv/ImportData.srv
@@ -1,0 +1,9 @@
+# A base-64 encoded string representing a compressed version of
+# the database contents.
+# The data itself is a gzipped JSON string representing the database contents
+# This is the same as the data output by the ExportData service, and is intended
+# to be used to restore the database to a previous state
+string data
+---
+# The state of the database after importing the data
+clearpath_dock_msgs/DockInfo[] docks

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ExportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ExportData.srv
@@ -1,7 +1,5 @@
 ---
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This can be written to a file or used with the ImportData.srv
 # to back-up/restore the database contents
 string data

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ImportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ImportData.srv
@@ -1,6 +1,4 @@
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This is the same as the data output by the ExportData service, and is intended
 # to be used to restore the database to a previous state
 string data

--- a/clearpath_outdoornav_msgs/clearpath_mission_scheduler_msgs/srv/ExportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_scheduler_msgs/srv/ExportData.srv
@@ -1,7 +1,5 @@
 ---
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This can be written to a file or used with the ImportData.srv
 # to back-up/restore the database contents
 string data

--- a/clearpath_outdoornav_msgs/clearpath_mission_scheduler_msgs/srv/ImportData.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_scheduler_msgs/srv/ImportData.srv
@@ -1,6 +1,4 @@
-# A base-64 encoded string representing a compressed version of
-# the database contents.
-# The data itself is a gzipped JSON string representing the database contents
+# A JSON string representing the database contents.
 # This is the same as the data output by the ExportData service, and is intended
 # to be used to restore the database to a previous state
 string data


### PR DESCRIPTION
Add messages/services relating to exporting & importing dock data from JSON data.

Remove the mentions of Gzipping & base64 encoding; the services that use these messages have been refactored to use raw JSON strings instead of lightly obfuscating them.

Resolves ONAV-1764