### PR TITLE
[ONAV-1772] Add 'allow_failure' boolean to Task message type

### DIFF
--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/CreateTask.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/CreateTask.srv
@@ -13,6 +13,10 @@ float64[] floats
 # The string arguments to pass to the action_server_name
 string[] strings
 
+# Boolean value which determines whether a mission using this task can continue
+# if this task fails to execute
+bool allow_failure
+
 # Optional list of Waypoint UUIDs to assign this task to automatically
 # The new task will be appended to the end of the existing Waypoints
 string[] assign_to_wp

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/UpdateTask.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/UpdateTask.srv
@@ -15,6 +15,10 @@ float64[] floats
 
 # The string data to pass to the action_server_name
 string[] strings
+
+# Boolean value which determines whether a mission using this task can continue
+# if this task fails to execute
+bool allow_failure
 ---
 # The edited Task, or null if no Task with the given ID exists
 clearpath_navigation_msgs/Task result

--- a/clearpath_outdoornav_msgs/clearpath_navigation_msgs/msg/Task.msg
+++ b/clearpath_outdoornav_msgs/clearpath_navigation_msgs/msg/Task.msg
@@ -19,3 +19,7 @@ float64[] floats
 # String data to be passed to the action_server_name
 # The exact meaning of these values is dependent on the underlying service
 string[] strings
+
+# Boolean value which determines whether a mission using this task can continue
+# if this task fails to execute
+bool allow_failure


### PR DESCRIPTION
- When set to True, any missions that execute this task will be allowed to continue if the task fails