### PR TITLE
Add a new mission manager service to import single missions

### DIFF
--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/CMakeLists.txt
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ add_service_files(
     GetTask.srv
     GetWaypoint.srv
     ImportData.srv
+    ImportMission.srv
     UpdateMission.srv
     UpdateTask.srv
     UpdateWaypoint.srv

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/CMakeLists.txt
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ add_service_files(
     CreateWaypoint.srv
     DeleteById.srv
     DeleteEverything.srv
+    DeleteMultiple.srv
     ExportData.srv
     GetAllMissions.srv
     GetAllTasks.srv

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/DeleteMultiple.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/DeleteMultiple.srv
@@ -1,0 +1,5 @@
+# A list of UUIDs of items we want to delete
+string[] uuids
+---
+# A list of UUIDs that we were asked to delete, but failed to
+string[] failed_uuids

--- a/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ImportMission.srv
+++ b/clearpath_outdoornav_msgs/clearpath_mission_manager_msgs/srv/ImportMission.srv
@@ -1,0 +1,5 @@
+# The Mission to import.  All UUIDs will be re-generated
+clearpath_navigation_msgs/Mission mission
+---
+# The generated mission with new UUIDs
+clearpath_navigation_msgs/Mission mission


### PR DESCRIPTION
Adds the ability to import a complete mission and its associated tasks & waypoints

Adds the ability to delete multiple IDs in a single request instead of calling the delete single item service over and over

Resolves ONAV-1926 and ONAV-1649