### PR TITLE
CORE-37112: clearpath_control_msgs package + StreamControl message type

### DIFF
--- a/clearpath_control_msgs/CMakeLists.txt
+++ b/clearpath_control_msgs/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.20)
+project(clearpath_control_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  msg/StreamControl.msg
+  DEPENDENCIES std_msgs builtin_interfaces
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/clearpath_control_msgs/CMakeLists.txt
+++ b/clearpath_control_msgs/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(clearpath_control_msgs)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(builtin_interfaces REQUIRED)

--- a/clearpath_control_msgs/msg/StreamControl.msg
+++ b/clearpath_control_msgs/msg/StreamControl.msg
@@ -1,0 +1,4 @@
+# Message for controlling a streaming device
+
+string stream      # The name of the stream to enable/disable
+bool enabled       # Whether to enable or disable the stream

--- a/clearpath_control_msgs/package.xml
+++ b/clearpath_control_msgs/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>clearpath_control_msgs</name>
+  <version>2.7.0</version>
+  <description>Clearpath control interface messages</description>
+  <maintainer email="natesh.narain@rockwellautomation.com">Natesh Narain</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/clearpath_control_msgs/package.xml
+++ b/clearpath_control_msgs/package.xml
@@ -5,7 +5,7 @@
   <version>2.7.0</version>
   <description>Clearpath control interface messages</description>
   <maintainer email="natesh.narain@rockwellautomation.com">Natesh Narain</maintainer>
-  <license>Apache-2.0</license>
+  <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
Add `clearpath_control_msgs` package. With `StreamControl` message.

**What is this**

I'm re-working OTTO's realsense support internally and part of that work involves dynamically controlling the streaming state of the cameras.

The new `StreamControl` message is intended to be that topic interface.

**Why a new package?**

Up for debate. Open to what we feel the best option is. Just putting it in `clearpath_platform_msgs` is the other most obvious thing to do.

My thought was basically:

* There is a control interface layer (robot intent -> hardware commands) that exists. Think what ros control does
* There's the Platform API that we expose to navigation / perception systems (the intent is new topics using this message are not exposed to that layer)
* Another message is planned, for `PowerControl` (for device recovery). Which in also intended to be implemented as a ros2_control controller at some point
* `clearpath_platform_msgs` tend to have robot specific semantics.

So I landed on this idea of a set of messages that are analogous to upstream's `control_msgs` (and we can consider migrating messages upstream if relevant).