### PR TITLE
CORE-36828: Power Control interface

### DIFF
--- a/clearpath_control_msgs/CMakeLists.txt
+++ b/clearpath_control_msgs/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   msg/StreamControl.msg
+  srv/PowerControl.srv
   DEPENDENCIES builtin_interfaces
 )
 

--- a/clearpath_control_msgs/srv/PowerControl.srv
+++ b/clearpath_control_msgs/srv/PowerControl.srv
@@ -1,0 +1,6 @@
+# Service for controlling USB port power state.
+
+bool power_on  # true requests port power ON, false requests port power OFF
+---
+bool success
+string message


### PR DESCRIPTION
Add a power control service.

The intent is this maps to a hardware interface with simple relay semantics: `on`/`off`. The service type itself is intended to be more meaningful then just a `bool` service.